### PR TITLE
Optimizations

### DIFF
--- a/fmn/sse/FeedQueue.py
+++ b/fmn/sse/FeedQueue.py
@@ -29,16 +29,12 @@ class FeedQueue:
         method_frame, header_frame, body = self.channel.basic_get(
             queue=self.queue_name)
         if not method_frame:
-            self.connection.close()
             return ''
 
         if method_frame.NAME == 'Basic.GetEmpty':
-            self.connection.close()
             return ''
         else:
             self.channel.basic_ack(delivery_tag=method_frame.delivery_tag)
-            self.connection.close()
-            # print body
             return body.decode('utf-8')
 
     def push_message(self, msg):

--- a/fmn/sse/sse_webserver.py
+++ b/fmn/sse/sse_webserver.py
@@ -53,8 +53,6 @@ class SSEServer(resource.Resource):
         :param request:  which connection disconnected or failed
         :return: remove the connection from the data structure
         '''
-        logger.error('Connection was disconnected from ' + str(request) +
-                     'removing from active connections')
         self.subscribers.remove_connection(request, key=key)
 
     def is_valid_path(self, path):

--- a/fmn/sse/subscriber.py
+++ b/fmn/sse/subscriber.py
@@ -56,6 +56,14 @@ class SSESubscriber:
                 self.push_sse(sse_msg, req)
 
     def get_feedqueue(self, key):
+        """
+        Return a feed queue based on the given key, which is in the format
+        (exchange, queue_name).
+
+        If the feed queue already exists, it is retrieved from the dictionary
+        that caches feed queues, otherwise it created and added to the
+        dictionary.
+        """
         exchange = key[0]
         queue_name = key[1]
 
@@ -70,6 +78,10 @@ class SSESubscriber:
             return fq
 
     def remove_feedqueue(self, key):
+        """
+        Remove a feedquee from the ``self.feedqueue`` dictionary and perform
+        cleanup.
+        """
         fq = self.feedqueue.pop(key[1])
         fq.channel.close()
         fq.connection.close()

--- a/tests/test_sse_subscriber.py
+++ b/tests/test_sse_subscriber.py
@@ -17,23 +17,6 @@ class MockLoopingCall(object):
         self.running = False
 
 
-class MockChanCon(object):
-    def __init__(self):
-        pass
-
-    def close(self):
-        pass
-
-
-class MockFeedQueue(object):
-    def __init__(self):
-        self.channel = MockChanCon()
-        self.connection = MockChanCon()
-
-    def receive_one_message(self):
-        return 'one message'
-
-
 class SSESubscriberTest(unittest.TestCase):
     def setUp(self):
         self.sse_sub = SSESubscriber()
@@ -112,7 +95,7 @@ class SSESubscriberTest(unittest.TestCase):
         # add the looping call and two connections
         lc_mock = MockLoopingCall(running=True)
         self.sse_sub.looping_calls['user'] = {'bob': lc_mock}
-        self.sse_sub.feedqueue['bob'] = MockFeedQueue()
+        self.sse_sub.feedqueue['bob'] = Mock()
 
         request = DummyRequest(postpath=['user', 'bob'])
         self.sse_sub.add_connection(request, request.postpath)
@@ -159,7 +142,8 @@ class SSESubscriberTest(unittest.TestCase):
         ])
 
     def test_get_fq_existing(self):
-        mock_fq = MockFeedQueue()
+        mock_fq = Mock()
+        mock_fq.receive_one_message.return_value = 'one message'
         self.sse_sub.feedqueue['bob'] = mock_fq
         self.assertEqual(self.sse_sub.get_feedqueue(['user', 'bob']), mock_fq)
 

--- a/tests/test_sse_subscriber.py
+++ b/tests/test_sse_subscriber.py
@@ -1,6 +1,8 @@
 import unittest
 from mock import patch, Mock
 from twisted.web.test.requesthelper import DummyRequest
+
+from fmn.sse.FeedQueue import FeedQueue
 from fmn.sse.subscriber import SSESubscriber
 
 
@@ -13,6 +15,23 @@ class MockLoopingCall(object):
 
     def stop(self):
         self.running = False
+
+
+class MockChanCon(object):
+    def __init__(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class MockFeedQueue(object):
+    def __init__(self):
+        self.channel = MockChanCon()
+        self.connection = MockChanCon()
+
+    def receive_one_message(self):
+        return 'one message'
 
 
 class SSESubscriberTest(unittest.TestCase):
@@ -93,6 +112,7 @@ class SSESubscriberTest(unittest.TestCase):
         # add the looping call and two connections
         lc_mock = MockLoopingCall(running=True)
         self.sse_sub.looping_calls['user'] = {'bob': lc_mock}
+        self.sse_sub.feedqueue['bob'] = MockFeedQueue()
 
         request = DummyRequest(postpath=['user', 'bob'])
         self.sse_sub.add_connection(request, request.postpath)
@@ -137,6 +157,14 @@ class SSESubscriberTest(unittest.TestCase):
         self.assertEqual(request2.written, [
             b"data: {'msg': 'unittest'}\r\n\r\n",
         ])
+
+    def test_get_fq_existing(self):
+        mock_fq = MockFeedQueue()
+        self.sse_sub.feedqueue['bob'] = mock_fq
+        self.assertEqual(self.sse_sub.get_feedqueue(['user', 'bob']), mock_fq)
+
+        msg = self.sse_sub.get_payload(['user', 'bob'])
+        self.assertEqual(msg, 'one message')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
shaved off about 40s of compute time using the following benchmark

Here's a profile log after running `python -m cProfile -o prof fmn/sse/sse_webserver.py`
with a stress test command `./wrk -t4 -c 800 -d300s http://localhost:8080/user/skrzepto`

----

Do note that the program still runs the same length of time but its not always processing. So more room for other requests to come in