### PR TITLE
Declare supported Python versions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,12 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Intended Audience :: Developers',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     cmdclass={'test': PyTest},
 )


### PR DESCRIPTION
This adds classifiers to the setup.py for the versions of Python this
project supports.

Note: I see there's talk of Python 3 support in the README, but I've not personally tried it yet, and I don't know what versions of Python 3 are supported. I also don't know if Python 2.6 needs to be supported or not. I thought the best place to have that discussion would be here and I can adjust the PR as necessary. 

Signed-off-by: Jeremy Cline jeremy@jcline.org
