### PR TITLE
Add additional configuration options for the SSE server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,12 @@ python:
  - "3.3"
  - "3.4"
  - "3.5"
+ - "3.6-dev"
+ - "nightly"
 install:
- - pip install --upgrade setuptools
+ - pip install --upgrade setuptools pip
+ - pip install -r requirements.txt
+ - pip install -r tests-requirements.txt
  - python setup.py develop
 script: python setup.py test
 notifications:

--- a/fedmsg.d/sse.py
+++ b/fedmsg.d/sse.py
@@ -9,6 +9,24 @@ config = {
     "fmn.sse.webserver.tcp_port": 8080,
     "fmn.sse.webserver.log": "sse.log",
 
+    # A regular expression using the standard Python re syntax that defines a
+    # whitelist of queues exposed by the SSE server.
+    'fmn.sse.webserver.queue_whitelist': '.+\.id\.fedoraproject\.org$',
+
+    # A regular expression using the standard Python re syntax that defines a
+    # blacklist for queues exposed by the SSE server. Any queue name that is
+    # matched by the regular expression will return a HTTP 403 to the client.
+    #
+    # Note: This is applied _after_ the whitelist so if the queue is matched
+    # by both regular expressions, the queue _will not_ be served.
+    'fmn.sse.webserver.queue_blacklist': None,
+
+    # The value to use with the 'Access-Control-Allow-Origin' HTTP header
+    'fmn.sse.webserver.allow_origin': '*',
+
+    # Define how many messages to prefetch from the AMQP server
+    'fmn.sse.pika.prefetch_count': 5,
+
     'endpoints': {
         # Just need this entry here for tests to pass on travis-ci.
     }

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 """ Setup file for fmn.sse """
-import sys
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
 
 
 def get_description():
@@ -27,20 +25,6 @@ def get_requirements(filename='requirements.txt'):
         ]
 
 
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
-
-
 setup(
     name='fmn.sse',
     version='0.1.1',
@@ -53,6 +37,7 @@ setup(
     license='GPL',
     install_requires=get_requirements('requirements.txt'),
     tests_require=get_requirements('tests-requirements.txt'),
+    test_suite='tests',
     packages=['fmn', 'fmn.sse'],
     namespace_packages=[],
     include_package_data=True,
@@ -69,5 +54,4 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
-    cmdclass={'test': PyTest},
 )

--- a/tests-requirements.txt
+++ b/tests-requirements.txt
@@ -1,3 +1,2 @@
+flake8
 mock
-pytest
-pytest-cov

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""This module runs flake8 on the entire code base"""
+
+import os
+import subprocess
+import unittest
+
+
+REPO_PATH = os.path.abspath(
+    os.path.dirname(os.path.join(os.path.dirname(__file__), '../')))
+
+
+class TestStyle(unittest.TestCase):
+    """Run flake8 on the repository directory as part of the unit tests."""
+
+    def test_code_with_flake8(self):
+        """Assert the code is PEP8-compliant"""
+        flake8_command = ['flake8', '--max-line-length', '100', REPO_PATH]
+        self.assertEqual(subprocess.call(flake8_command), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds a blacklist and whitelist for queue names that the SSE server
will serve. It also lets the QoS options for the queue consumer be
configured and the access control header to be set.

fixes #57

Signed-off-by: Jeremy Cline <jeremy@jcline.org>