### PR TITLE
Add a Twisted application file and configure logging

### DIFF
--- a/fedmsg.d/logging.py
+++ b/fedmsg.d/logging.py
@@ -3,10 +3,11 @@
 config = dict(
     logging=dict(
         version=1,
+        disable_existing_loggers=False,
         formatters=dict(
             bare={
-                "datefmt": "%Y-%m-%d %H:%M:%S",
-                "format": "[%(asctime)s][%(name)10s %(levelname)7s] %(message)s"
+                "datefmt": "%Y-%m-%dT%H:%M:%S%z",
+                "format": "%(asctime)s [%(name)s#%(levelname)s] %(message)s"
             },
         ),
         handlers=dict(
@@ -23,11 +24,23 @@ config = dict(
                 "propagate": False,
                 "handlers": ["console"],
             },
+            fmn={
+                "level": "DEBUG",
+                "propagate": False,
+                "handlers": ["console"],
+            },
             moksha={
                 "level": "DEBUG",
                 "propagate": False,
                 "handlers": ["console"],
             },
+
         ),
+        # The root logger configuration; this is a catch-all configuration
+        # that applies to all log messages not handled by a different logger
+        root={
+            'level': 'INFO',
+            'handlers': ['console'],
+        },
     ),
 )

--- a/fedmsg.d/sse.py
+++ b/fedmsg.d/sse.py
@@ -5,9 +5,11 @@ config = {
     "fmn.sse.pika.port": 5672,
     "fmn.sse.pika.msg_expiration": 3600000,  # 1 hour in ms
 
-    # SSE WebServer
+    # SSE Web server configuration
     "fmn.sse.webserver.tcp_port": 8080,
-    "fmn.sse.webserver.log": "sse.log",
+    # A list of interfaces to listen to ('127.0.0.1', for example); if none
+    # are specified the server listens on all available interfaces.
+    'fmn.sse.webserver.interfaces': [],
 
     'endpoints': {
         # Just need this entry here for tests to pass on travis-ci.

--- a/systemd/fmn-sse@.service
+++ b/systemd/fmn-sse@.service
@@ -4,7 +4,7 @@ After=network.target
 Documentation=https://github.com/fedora-infra/fmn.sse/
 
 [Service]
-ExecStart=/usr/bin/python2 /usr/lib/python2.7/site-packages/fmn/sse/sse_webserver.py
+ExecStart=/usr/bin/twistd -n -l - -y /usr/lib/share/fmn.sse/sse_server.tac
 Type=simple
 User=root
 Group=root

--- a/usr/share/fmn.sse/sse_server.tac
+++ b/usr/share/fmn.sse/sse_server.tac
@@ -1,0 +1,38 @@
+from gettext import gettext as _
+import logging.config
+
+from fedmsg import config as fedmsg_config
+from twisted.application import internet, service
+from twisted.web import server
+
+from fmn.sse.server import SSEServer
+
+
+app_config = fedmsg_config.load_config()
+
+
+logging.config.dictConfig(app_config.get('logging'))
+_log = logging.getLogger('fmn.sse')
+_log.info('Successfully configured logging for the SSE Server')
+
+
+# Configure the twisted application itself.
+application = service.Application(_('FMN Server Sent Events Server'))
+site = server.Site(SSEServer())
+service_collection = service.IServiceCollection(application)
+
+port = app_config.get('fmn.sse.webserver.tcp_port', 8080)
+interfaces = app_config.get('fmn.sse.webserver.interfaces')
+
+if interfaces:
+    for interface in interfaces.split(','):
+        i = internet.TCPServer(int(port), site, interface=interface.strip())
+        i.setServiceParent(service_collection)
+    _log.info(_('SSE server is listening to port {0} on the {1} '
+                'interfaces').format(port, interfaces))
+else:
+    # If not defined, listen on all interfaces
+    i = internet.TCPServer(int(port), site)
+    i.setServiceParent(service_collection)
+    _log.info(_('SSE server is listening to port {0} on all available '
+                'interfaces').format(port))


### PR DESCRIPTION
Twisted uses its own (non-blocking) logging system. It can be configured
in simple ways using the ``twistd`` tool used to launch the application
which should suffice for now. However, there are third-party libraries
that use the standard Python logging module, so this is configured as
part of the application's setup.

fixes #58

Signed-off-by: Jeremy Cline <jeremy@jcline.org>